### PR TITLE
chore: permite saída do valor gerado no console.log

### DIFF
--- a/.github/workflows/generate-token.yml
+++ b/.github/workflows/generate-token.yml
@@ -31,5 +31,7 @@ jobs:
         done
 
     - name: Generate token
-      run: npm run generate:token
+      run: |
+        jwt=$(npm run generate:token | tail -n 1)
+        echo -e "Anonymous JWT token is:\n$jwt"
       working-directory: valida_cpf_usuario


### PR DESCRIPTION
Corrige saída do console log para que seja exibido no actions (o `console.log` é bloqueado por padrão.